### PR TITLE
feat: derive endpoint from auth.domain for WorkBuddy Global (workbuddy.ai) accounts

### DIFF
--- a/signin.py
+++ b/signin.py
@@ -367,7 +367,18 @@ def main():
         out = {"result": "NO_SESSION", "report": str(e)}
         print(json.dumps(out, ensure_ascii=False))
         return 1
-    endpoint = ((session.get("auth") or {}).get("endpoint") or DEFAULT_ENDPOINT).rstrip("/")
+    auth_meta = session.get("auth") or {}
+    endpoint = (auth_meta.get("endpoint") or "").rstrip("/")
+    if not endpoint:
+        # Global accounts (workbuddy.ai) export auth files that carry domain
+        # but no endpoint key — derive the endpoint from the domain before
+        # falling back to the CN default, otherwise requests for a Global
+        # token would hit copilot.tencent.com and fail with 401.
+        domain = (auth_meta.get("domain") or "").strip()
+        if domain:
+            endpoint = ("https://" + domain.lstrip("./")).rstrip("/")
+        else:
+            endpoint = DEFAULT_ENDPOINT
 
     if action in ("auto", "silent"):
         code, out = run_auto(headers, endpoint)


### PR DESCRIPTION
## Summary

Global (workbuddy.ai) account exports carry `auth.domain` but **no `auth.endpoint`** key, so `main()` fell straight back to the CN default (`https://copilot.tencent.com`) and every request 401'd for a Global token.

This PR derives the endpoint from `auth.domain` (e.g. `www.workbuddy.ai` → `https://www.workbuddy.ai`) before falling back to `DEFAULT_ENDPOINT`, so a domain-bearing auth file routes to the correct realm without needing an explicit `endpoint` field.

## Why

- WorkBuddy Global login (e.g. via OAuth captured through CLI-style flows) stores `{"auth":{"domain":"www.workbuddy.ai",...},"account":{...}}` — exactly the shape `load_session()` accepts, but the billing/growth endpoints live on the Global host.
- Current behavior silently routes Global tokens to the CN host → `401` with a misleading "re-login" hint.

## Testing

- Windows Server, Python 3.13
- Auth file: global token with `auth.domain = www.workbuddy.ai`, no `endpoint` key
- `python signin.py status` → `HTTP 200, code 0` from `https://www.workbuddy.ai/v2/billing/meter/checkin-activity-status` ✅
- CN flow untouched: files with an explicit `auth.endpoint` or no domain still resolve exactly as before


<!-- start pr-codex -->

---

## PR-Codex overview
This PR refines how the `endpoint` is determined in the `signin.py` file. It adds logic to derive the `endpoint` from the `domain` if it's available, improving the handling of global accounts that lack the `endpoint` key.

### Detailed summary
- Introduced `auth_meta` to hold the session's `auth` data.
- Modified `endpoint` assignment to check for `endpoint` in `auth_meta`.
- Added logic to derive `endpoint` from `domain` if it exists.
- Implemented a fallback to `DEFAULT_ENDPOINT` if no `domain` or `endpoint` is found.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->